### PR TITLE
Update display value whenever the data prop changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-circular-chart",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "circular chart for react-native.",
   "main": "index.js",
   "module": "index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -228,6 +228,10 @@ export const DonutChart = ({
     }).start();
   }, []);
 
+  useEffect(() => {
+    setDisplayValue(data[0]);
+  }, [data]);
+
   const onUpdateDisplayValue = (value: DonutItem, index: number) => {
     setDisplayValue(value);
     animateOpacity.setValue(0);


### PR DESCRIPTION
As the title suggests this pull request addresses the data updates changing the display value since the displayValue is set to an initial value of `data[0]`

This line:

`const [displayValue, setDisplayValue] = useState<DonutItem>(data[0]);`

Only get initialized once and never updates so a `useEffect` is a workaround.